### PR TITLE
Nvanvuong/kafka oauth aad

### DIFF
--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
@@ -319,9 +319,9 @@ public class ConsumeKafkaRecord_2_6 extends AbstractProcessor implements KafkaCl
         descriptors.add(KERBEROS_SERVICE_NAME);
         descriptors.add(KERBEROS_PRINCIPAL);
         descriptors.add(KERBEROS_KEYTAB);
-        descriptors.add(TENANT_ID);
-        descriptors.add(APP_ID);
-        descriptors.add(APP_SECRET);
+        descriptors.add(AZURE_TENANT_ID);
+        descriptors.add(AZURE_APP_ID);
+        descriptors.add(AZURE_APP_SECRET);
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafkaRecord_2_6.java
@@ -319,6 +319,9 @@ public class ConsumeKafkaRecord_2_6 extends AbstractProcessor implements KafkaCl
         descriptors.add(KERBEROS_SERVICE_NAME);
         descriptors.add(KERBEROS_PRINCIPAL);
         descriptors.add(KERBEROS_KEYTAB);
+        descriptors.add(TENANT_ID);
+        descriptors.add(APP_ID);
+        descriptors.add(APP_SECRET);
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
@@ -272,6 +272,9 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
         descriptors.add(KERBEROS_SERVICE_NAME);
         descriptors.add(KERBEROS_PRINCIPAL);
         descriptors.add(KERBEROS_KEYTAB);
+        descriptors.add(TENANT_ID);
+        descriptors.add(APP_ID);
+        descriptors.add(APP_SECRET);
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/ConsumeKafka_2_6.java
@@ -272,9 +272,9 @@ public class ConsumeKafka_2_6 extends AbstractProcessor implements KafkaClientCo
         descriptors.add(KERBEROS_SERVICE_NAME);
         descriptors.add(KERBEROS_PRINCIPAL);
         descriptors.add(KERBEROS_KEYTAB);
-        descriptors.add(TENANT_ID);
-        descriptors.add(APP_ID);
-        descriptors.add(APP_SECRET);
+        descriptors.add(AZURE_TENANT_ID);
+        descriptors.add(AZURE_APP_ID);
+        descriptors.add(AZURE_APP_SECRET);
         descriptors.add(SASL_USERNAME);
         descriptors.add(SASL_PASSWORD);
         descriptors.add(TOKEN_AUTHENTICATION);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -348,9 +348,9 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         properties.add(KERBEROS_SERVICE_NAME);
         properties.add(KERBEROS_PRINCIPAL);
         properties.add(KERBEROS_KEYTAB);
-        properties.add(TENANT_ID);
-        properties.add(APP_ID);
-        properties.add(APP_SECRET);
+        properties.add(AZURE_TENANT_ID);
+        properties.add(AZURE_APP_ID);
+        properties.add(AZURE_APP_SECRET);
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafkaRecord_2_6.java
@@ -348,6 +348,9 @@ public class PublishKafkaRecord_2_6 extends AbstractProcessor implements KafkaPu
         properties.add(KERBEROS_SERVICE_NAME);
         properties.add(KERBEROS_PRINCIPAL);
         properties.add(KERBEROS_KEYTAB);
+        properties.add(TENANT_ID);
+        properties.add(APP_ID);
+        properties.add(APP_SECRET);
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(TOKEN_AUTHENTICATION);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
@@ -304,9 +304,9 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         properties.add(KERBEROS_SERVICE_NAME);
         properties.add(KERBEROS_PRINCIPAL);
         properties.add(KERBEROS_KEYTAB);
-        properties.add(TENANT_ID);
-        properties.add(APP_ID);
-        properties.add(APP_SECRET);
+        properties.add(AZURE_TENANT_ID);
+        properties.add(AZURE_APP_ID);
+        properties.add(AZURE_APP_SECRET);
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(AWS_PROFILE_NAME);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-2-6-processors/src/main/java/org/apache/nifi/processors/kafka/pubsub/PublishKafka_2_6.java
@@ -304,6 +304,9 @@ public class PublishKafka_2_6 extends AbstractProcessor implements KafkaPublishC
         properties.add(KERBEROS_SERVICE_NAME);
         properties.add(KERBEROS_PRINCIPAL);
         properties.add(KERBEROS_KEYTAB);
+        properties.add(TENANT_ID);
+        properties.add(APP_ID);
+        properties.add(APP_SECRET);
         properties.add(SASL_USERNAME);
         properties.add(SASL_PASSWORD);
         properties.add(AWS_PROFILE_NAME);

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/pom.xml
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/pom.xml
@@ -55,5 +55,15 @@
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-mock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>msal4j</artifactId>
+            <version>1.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka2.6.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/aad/AADAuthenticateCallbackHandler.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/aad/AADAuthenticateCallbackHandler.java
@@ -1,6 +1,10 @@
 package org.apache.nifi.kafka.shared.aad;
 
-import com.microsoft.aad.msal4j.*;
+import com.microsoft.aad.msal4j.ClientCredentialFactory;
+import com.microsoft.aad.msal4j.ClientCredentialParameters;
+import com.microsoft.aad.msal4j.ConfidentialClientApplication;
+import com.microsoft.aad.msal4j.IClientCredential;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
@@ -16,13 +20,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
-public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHandler {
-
-    final static ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
+public class AADAuthenticateCallbackHandler implements AuthenticateCallbackHandler {
 
     public static String authority;
     public static String appId;
@@ -79,7 +79,6 @@ public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHa
         }
 
         IAuthenticationResult authResult = this.aadClient.acquireToken(this.aadParameters).get();
-        System.out.println("TOKEN ACQUIRED");
 
         return new OAuthBearerTokenImp(authResult.accessToken(), authResult.expiresOnDate());
     }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/aad/CustomAuthenticateCallbackHandler.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/aad/CustomAuthenticateCallbackHandler.java
@@ -40,9 +40,7 @@ public class CustomAuthenticateCallbackHandler implements AuthenticateCallbackHa
                 ClientCredentialParameters.builder(Collections.singleton(sbUri + "/.default"))
                         .build();
 
-        authority = "https://login.microsoftonline.com/" + authority + "/"; // 09b6b9cc-ba75-4e9f-b00c-cdef49725940 replace <tenant-id> with your tenant id
-//        appId = "d928f1fe-ced6-4824-ab21-dc4f10825a06"; // also called client id
-//        appSecret = "ezN8Q~gGhhLo6jpC_JwH.tOjbNLop3Bd~M0T1aX6"; // also called client secret
+        authority = "https://login.microsoftonline.com/" + authority + "/";
     }
 
     @Override

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/aad/OAuthBearerTokenImp.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/aad/OAuthBearerTokenImp.java
@@ -1,0 +1,43 @@
+package org.apache.nifi.kafka.shared.aad;
+
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+
+import java.util.Date;
+import java.util.Set;
+
+
+public class OAuthBearerTokenImp implements OAuthBearerToken
+{
+    String token;
+    long lifetimeMs;
+
+    public OAuthBearerTokenImp(final String token, Date expiresOn) {
+        this.token = token;
+        this.lifetimeMs = expiresOn.getTime();
+    }
+
+    @Override
+    public String value() {
+        return this.token;
+    }
+
+    @Override
+    public Set<String> scope() {
+        return null;
+    }
+
+    @Override
+    public long lifetimeMs() {
+        return this.lifetimeMs;
+    }
+
+    @Override
+    public String principalName() {
+        return null;
+    }
+
+    @Override
+    public Long startTimeMs() {
+        return null;
+    }
+}

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -62,6 +62,48 @@ public interface KafkaClientComponent {
             .defaultValue(SaslMechanism.GSSAPI.getValue())
             .build();
 
+    PropertyDescriptor TENANT_ID = new PropertyDescriptor.Builder()
+            .name("aad.tenant_id")
+            .displayName("Tenant ID")
+            .description("Tenant ID provided when using Azure Active Directory")
+            .sensitive(true)
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .dependsOn(
+                    SASL_MECHANISM,
+                    SaslMechanism.OAUTHBEARER.getValue()
+            )
+            .build();
+
+    PropertyDescriptor APP_ID = new PropertyDescriptor.Builder()
+            .name("aad.app_id")
+            .displayName("App Id")
+            .description("APP ID provided when using Azure Active Directory")
+            .sensitive(true)
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .dependsOn(
+                    SASL_MECHANISM,
+                    SaslMechanism.OAUTHBEARER.getValue()
+            )
+            .build();
+
+    PropertyDescriptor APP_SECRET = new PropertyDescriptor.Builder()
+            .name("aad.app_secret")
+            .displayName("App Secret")
+            .description("App Secret provided when using Azure Active Directory")
+            .sensitive(true)
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+            .dependsOn(
+                    SASL_MECHANISM,
+                    SaslMechanism.OAUTHBEARER.getValue()
+            )
+            .build();
+
     PropertyDescriptor SASL_USERNAME = new PropertyDescriptor.Builder()
             .name("sasl.username")
             .displayName("Username")

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/component/KafkaClientComponent.java
@@ -62,45 +62,45 @@ public interface KafkaClientComponent {
             .defaultValue(SaslMechanism.GSSAPI.getValue())
             .build();
 
-    PropertyDescriptor TENANT_ID = new PropertyDescriptor.Builder()
+    PropertyDescriptor AZURE_TENANT_ID = new PropertyDescriptor.Builder()
             .name("aad.tenant_id")
-            .displayName("Tenant ID")
-            .description("Tenant ID provided when using Azure Active Directory")
+            .displayName("Azure Tenant ID")
+            .description("Azure Tenant ID provided when using Azure Active Directory")
             .sensitive(true)
             .required(false)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .dependsOn(
                     SASL_MECHANISM,
-                    SaslMechanism.OAUTHBEARER.getValue()
+                    SaslMechanism.AADOAUTHBEARER.getValue()
             )
             .build();
 
-    PropertyDescriptor APP_ID = new PropertyDescriptor.Builder()
+    PropertyDescriptor AZURE_APP_ID = new PropertyDescriptor.Builder()
             .name("aad.app_id")
-            .displayName("App Id")
-            .description("APP ID provided when using Azure Active Directory")
+            .displayName("Azure App Id")
+            .description("Azure APP ID provided when using Azure Active Directory")
             .sensitive(true)
             .required(false)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .dependsOn(
                     SASL_MECHANISM,
-                    SaslMechanism.OAUTHBEARER.getValue()
+                    SaslMechanism.AADOAUTHBEARER.getValue()
             )
             .build();
 
-    PropertyDescriptor APP_SECRET = new PropertyDescriptor.Builder()
+    PropertyDescriptor AZURE_APP_SECRET = new PropertyDescriptor.Builder()
             .name("aad.app_secret")
-            .displayName("App Secret")
-            .description("App Secret provided when using Azure Active Directory")
+            .displayName("Azure App Secret")
+            .description("Azure App Secret provided when using Azure Active Directory")
             .sensitive(true)
             .required(false)
             .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
             .expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
             .dependsOn(
                     SASL_MECHANISM,
-                    SaslMechanism.OAUTHBEARER.getValue()
+                    SaslMechanism.AADOAUTHBEARER.getValue()
             )
             .build();
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AADLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/AADLoginConfigProvider.java
@@ -1,0 +1,20 @@
+package org.apache.nifi.kafka.shared.login;
+
+import org.apache.nifi.context.PropertyContext;
+
+import static javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
+
+public class AADLoginConfigProvider implements LoginConfigProvider {
+
+    private static final String MODULE_CLASS = "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule";
+
+
+    @Override
+    public String getConfiguration(PropertyContext context) {
+
+        final LoginConfigBuilder builder = new LoginConfigBuilder(MODULE_CLASS, REQUIRED);
+
+        return builder.build();
+    }
+
+}

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
@@ -37,7 +37,7 @@ public class DelegatingLoginConfigProvider implements LoginConfigProvider {
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_256, SCRAM_PROVIDER);
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_512, SCRAM_PROVIDER);
         PROVIDERS.put(SaslMechanism.AWS_MSK_IAM, new AwsMskIamLoginConfigProvider());
-        PROVIDERS.put(SaslMechanism.OAUTHBEARER, new AADLoginConfigProvider());
+        PROVIDERS.put(SaslMechanism.AADOAUTHBEARER, new AADLoginConfigProvider());
     }
 
     /**

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/login/DelegatingLoginConfigProvider.java
@@ -37,6 +37,7 @@ public class DelegatingLoginConfigProvider implements LoginConfigProvider {
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_256, SCRAM_PROVIDER);
         PROVIDERS.put(SaslMechanism.SCRAM_SHA_512, SCRAM_PROVIDER);
         PROVIDERS.put(SaslMechanism.AWS_MSK_IAM, new AwsMskIamLoginConfigProvider());
+        PROVIDERS.put(SaslMechanism.OAUTHBEARER, new AADLoginConfigProvider());
     }
 
     /**

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KafkaClientProperty.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/KafkaClientProperty.java
@@ -26,6 +26,8 @@ public enum KafkaClientProperty {
 
     SASL_CLIENT_CALLBACK_HANDLER_CLASS("sasl.client.callback.handler.class"),
 
+    SASL_LOGIN_CALLBACK_HANDLER_CLASS("sasl.login.callback.handler.class"),
+
     SSL_KEYSTORE_LOCATION("ssl.keystore.location"),
 
     SSL_KEYSTORE_PASSWORD("ssl.keystore.password"),

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
@@ -31,6 +31,8 @@ public enum SaslMechanism implements DescribedValue {
 
     PLAIN("PLAIN", "PLAIN", "Plain username and password authentication"),
 
+    OAUTHBEARER("OAUTHBEARER", "OAUTHBEARER", "Login with Azure Active Directory"),
+
     SCRAM_SHA_256("SCRAM-SHA-256", "SCRAM-SHA-256", "Salted Challenge Response Authentication Mechanism using SHA-512 with username and password"),
 
     SCRAM_SHA_512("SCRAM-SHA-512", "SCRAM-SHA-512", "Salted Challenge Response Authentication Mechanism using SHA-256 with username and password"),

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/SaslMechanism.java
@@ -31,7 +31,7 @@ public enum SaslMechanism implements DescribedValue {
 
     PLAIN("PLAIN", "PLAIN", "Plain username and password authentication"),
 
-    OAUTHBEARER("OAUTHBEARER", "OAUTHBEARER", "Login with Azure Active Directory"),
+    AADOAUTHBEARER("OAUTHBEARER", "AADOAUTHBEARER", "Login with Azure Active Directory"),
 
     SCRAM_SHA_256("SCRAM-SHA-256", "SCRAM-SHA-256", "Salted Challenge Response Authentication Mechanism using SHA-512 with username and password"),
 

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
@@ -16,15 +16,30 @@
  */
 package org.apache.nifi.kafka.shared.property.provider;
 
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.*;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.AZURE_APP_ID;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.AZURE_APP_SECRET;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.AZURE_TENANT_ID;
 import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.BOOTSTRAP_SERVERS;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.*;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SECURITY_PROTOCOL;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SSL_CONTEXT_SERVICE;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_JAAS_CONFIG;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_LOGIN_CALLBACK_HANDLER_CLASS;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_LOGIN_CLASS;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_LOCATION;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_PASSWORD;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_TYPE;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEY_PASSWORD;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_LOCATION;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_PASSWORD;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_TYPE;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_MECHANISM;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.ConfigurationContext;
-import org.apache.nifi.kafka.shared.aad.CustomAuthenticateCallbackHandler;
+import org.apache.nifi.kafka.shared.aad.AADAuthenticateCallbackHandler;
 import org.apache.nifi.kafka.shared.login.DelegatingLoginConfigProvider;
 import org.apache.nifi.kafka.shared.login.LoginConfigProvider;
 import org.apache.nifi.kafka.shared.property.SaslMechanism;
@@ -50,7 +65,7 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
 
     public static final String SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS = "software.amazon.msk.auth.iam.IAMClientCallbackHandler";
 
-    public static final String AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS = "org.apache.nifi.kafka.shared.aad.CustomAuthenticateCallbackHandler";
+    public static final String AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS = "org.apache.nifi.kafka.shared.aad.AADAuthenticateCallbackHandler";
 
     private static final LoginConfigProvider LOGIN_CONFIG_PROVIDER = new DelegatingLoginConfigProvider();
 
@@ -84,12 +99,12 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
                 properties.put(SASL_LOGIN_CLASS.getProperty(), SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
             } else if (SaslMechanism.AWS_MSK_IAM == saslMechanism && isAwsMskIamCallbackHandlerFound()) {
                 properties.put(SASL_CLIENT_CALLBACK_HANDLER_CLASS.getProperty(), SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
-            } else if (SaslMechanism.OAUTHBEARER == saslMechanism && isCustomAADLoginFound()) {
+            } else if (SaslMechanism.AADOAUTHBEARER == saslMechanism && isCustomAADLoginFound()) {
                 properties.put(SASL_LOGIN_CALLBACK_HANDLER_CLASS.getProperty(), AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS);
-                CustomAuthenticateCallbackHandler.authority = context.getProperty(TENANT_ID).evaluateAttributeExpressions().getValue();
-                CustomAuthenticateCallbackHandler.appId = context.getProperty(APP_ID).evaluateAttributeExpressions().getValue();
-                CustomAuthenticateCallbackHandler.appSecret = context.getProperty(APP_SECRET).evaluateAttributeExpressions().getValue();
-                CustomAuthenticateCallbackHandler.bootstrapServer = context.getProperty(BOOTSTRAP_SERVERS).evaluateAttributeExpressions().getValue();
+                AADAuthenticateCallbackHandler.authority = context.getProperty(AZURE_TENANT_ID).evaluateAttributeExpressions().getValue();
+                AADAuthenticateCallbackHandler.appId = context.getProperty(AZURE_APP_ID).evaluateAttributeExpressions().getValue();
+                AADAuthenticateCallbackHandler.appSecret = context.getProperty(AZURE_APP_SECRET).evaluateAttributeExpressions().getValue();
+                AADAuthenticateCallbackHandler.bootstrapServer = context.getProperty(BOOTSTRAP_SERVERS).evaluateAttributeExpressions().getValue();
             }
         }
     }

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/property/provider/StandardKafkaPropertyProvider.java
@@ -16,24 +16,15 @@
  */
 package org.apache.nifi.kafka.shared.property.provider;
 
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_MECHANISM;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SECURITY_PROTOCOL;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SSL_CONTEXT_SERVICE;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_CLIENT_CALLBACK_HANDLER_CLASS;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_JAAS_CONFIG;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SASL_LOGIN_CLASS;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_LOCATION;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_PASSWORD;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEYSTORE_TYPE;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_KEY_PASSWORD;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_LOCATION;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_PASSWORD;
-import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.SSL_TRUSTSTORE_TYPE;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.*;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.BOOTSTRAP_SERVERS;
+import static org.apache.nifi.kafka.shared.property.KafkaClientProperty.*;
 
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.context.PropertyContext;
 import org.apache.nifi.controller.ConfigurationContext;
+import org.apache.nifi.kafka.shared.aad.CustomAuthenticateCallbackHandler;
 import org.apache.nifi.kafka.shared.login.DelegatingLoginConfigProvider;
 import org.apache.nifi.kafka.shared.login.LoginConfigProvider;
 import org.apache.nifi.kafka.shared.property.SaslMechanism;
@@ -58,6 +49,8 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
     private static final String SASL_GSSAPI_CUSTOM_LOGIN_CLASS = "org.apache.nifi.processors.kafka.pubsub.CustomKerberosLogin";
 
     public static final String SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS = "software.amazon.msk.auth.iam.IAMClientCallbackHandler";
+
+    public static final String AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS = "org.apache.nifi.kafka.shared.aad.CustomAuthenticateCallbackHandler";
 
     private static final LoginConfigProvider LOGIN_CONFIG_PROVIDER = new DelegatingLoginConfigProvider();
 
@@ -91,6 +84,12 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
                 properties.put(SASL_LOGIN_CLASS.getProperty(), SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
             } else if (SaslMechanism.AWS_MSK_IAM == saslMechanism && isAwsMskIamCallbackHandlerFound()) {
                 properties.put(SASL_CLIENT_CALLBACK_HANDLER_CLASS.getProperty(), SASL_AWS_MSK_IAM_CLIENT_CALLBACK_HANDLER_CLASS);
+            } else if (SaslMechanism.OAUTHBEARER == saslMechanism && isCustomAADLoginFound()) {
+                properties.put(SASL_LOGIN_CALLBACK_HANDLER_CLASS.getProperty(), AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS);
+                CustomAuthenticateCallbackHandler.authority = context.getProperty(TENANT_ID).evaluateAttributeExpressions().getValue();
+                CustomAuthenticateCallbackHandler.appId = context.getProperty(APP_ID).evaluateAttributeExpressions().getValue();
+                CustomAuthenticateCallbackHandler.appSecret = context.getProperty(APP_SECRET).evaluateAttributeExpressions().getValue();
+                CustomAuthenticateCallbackHandler.bootstrapServer = context.getProperty(BOOTSTRAP_SERVERS).evaluateAttributeExpressions().getValue();
             }
         }
     }
@@ -167,6 +166,10 @@ public class StandardKafkaPropertyProvider implements KafkaPropertyProvider {
 
     private static boolean isCustomKerberosLoginFound() {
         return isClassFound(SASL_GSSAPI_CUSTOM_LOGIN_CLASS);
+    }
+
+    public static boolean isCustomAADLoginFound() {
+        return isClassFound(AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS);
     }
 
     public static boolean isAwsMskIamCallbackHandlerFound() {

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
@@ -34,8 +34,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.*;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.APP_SECRET;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.AZURE_APP_ID;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.AZURE_APP_SECRET;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.AZURE_TENANT_ID;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_CREDENTIALS_SERVICE;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_KEYTAB;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_PRINCIPAL;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_SERVICE_NAME;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_MECHANISM;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_PASSWORD;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_USERNAME;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SECURITY_PROTOCOL;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SELF_CONTAINED_KERBEROS_USER_SERVICE;
 
 /**
  * Custom Validation function for components supporting Kafka clients
@@ -252,7 +262,7 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
         if (saslMechanismProperty.isSet()) {
             final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(saslMechanismProperty.getValue());
 
-            if (SaslMechanism.OAUTHBEARER == saslMechanism) {
+            if (SaslMechanism.AADOAUTHBEARER == saslMechanism) {
                 if (!StandardKafkaPropertyProvider.isCustomAADLoginFound()) {
                     final String explanation = String.format("[%s] required class not found: Kafka modules must be compiled with AAD OAUTHBEARER enabled",
                             StandardKafkaPropertyProvider.AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS);
@@ -263,29 +273,29 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
                             .explanation(explanation)
                             .build());
                 }
-                String tenantId = validationContext.getProperty(TENANT_ID).evaluateAttributeExpressions().getValue();
+                String tenantId = validationContext.getProperty(AZURE_TENANT_ID).evaluateAttributeExpressions().getValue();
                 if (tenantId == null || tenantId.isEmpty()) {
-                    final String explanation = String.format("[%s] required when [%s] mechanism used", TENANT_ID.getDisplayName(), saslMechanism);
+                    final String explanation = String.format("[%s] required when [%s] mechanism used", AZURE_TENANT_ID.getDisplayName(), saslMechanism);
                     results.add(new ValidationResult.Builder()
-                            .subject(TENANT_ID.getDisplayName())
+                            .subject(AZURE_TENANT_ID.getDisplayName())
                             .valid(false)
                             .explanation(explanation)
                             .build());
                 }
-                String appId = validationContext.getProperty(APP_ID).evaluateAttributeExpressions().getValue();
+                String appId = validationContext.getProperty(AZURE_APP_ID).evaluateAttributeExpressions().getValue();
                 if (appId == null || appId.isEmpty()) {
-                    final String explanation = String.format("[%s] required when [%s] mechanism used", APP_ID.getDisplayName(), saslMechanism);
+                    final String explanation = String.format("[%s] required when [%s] mechanism used", AZURE_APP_ID.getDisplayName(), saslMechanism);
                     results.add(new ValidationResult.Builder()
-                            .subject(APP_ID.getDisplayName())
+                            .subject(AZURE_APP_ID.getDisplayName())
                             .valid(false)
                             .explanation(explanation)
                             .build());
                 }
-                String appSecret = validationContext.getProperty(APP_SECRET).evaluateAttributeExpressions().getValue();
+                String appSecret = validationContext.getProperty(AZURE_APP_SECRET).evaluateAttributeExpressions().getValue();
                 if (appSecret == null || appSecret.isEmpty()) {
-                    final String explanation = String.format("[%s] required when [%s] mechanism used", APP_SECRET.getDisplayName(), saslMechanism);
+                    final String explanation = String.format("[%s] required when [%s] mechanism used", AZURE_APP_SECRET.getDisplayName(), saslMechanism);
                     results.add(new ValidationResult.Builder()
-                            .subject(APP_SECRET.getDisplayName())
+                            .subject(AZURE_APP_SECRET.getDisplayName())
                             .valid(false)
                             .explanation(explanation)
                             .build());

--- a/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
+++ b/nifi-nar-bundles/nifi-kafka-bundle/nifi-kafka-shared/src/main/java/org/apache/nifi/kafka/shared/validation/KafkaClientCustomValidationFunction.java
@@ -34,15 +34,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_CREDENTIALS_SERVICE;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_KEYTAB;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_PRINCIPAL;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.KERBEROS_SERVICE_NAME;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_MECHANISM;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_PASSWORD;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SASL_USERNAME;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SECURITY_PROTOCOL;
-import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.SELF_CONTAINED_KERBEROS_USER_SERVICE;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.*;
+import static org.apache.nifi.kafka.shared.component.KafkaClientComponent.APP_SECRET;
 
 /**
  * Custom Validation function for components supporting Kafka clients
@@ -76,6 +69,7 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
         validateKerberosCredentials(validationContext, results);
         validateUsernamePassword(validationContext, results);
         validateAwsMskIamMechanism(validationContext, results);
+        validateAADOAUTHBEARERMechanism(validationContext, results);
         return results;
     }
 
@@ -249,6 +243,53 @@ public class KafkaClientCustomValidationFunction implements Function<ValidationC
                         .valid(false)
                         .explanation(explanation)
                         .build());
+            }
+        }
+    }
+
+    private void validateAADOAUTHBEARERMechanism(final ValidationContext validationContext, final Collection<ValidationResult> results) {
+        final PropertyValue saslMechanismProperty = validationContext.getProperty(SASL_MECHANISM);
+        if (saslMechanismProperty.isSet()) {
+            final SaslMechanism saslMechanism = SaslMechanism.getSaslMechanism(saslMechanismProperty.getValue());
+
+            if (SaslMechanism.OAUTHBEARER == saslMechanism) {
+                if (!StandardKafkaPropertyProvider.isCustomAADLoginFound()) {
+                    final String explanation = String.format("[%s] required class not found: Kafka modules must be compiled with AAD OAUTHBEARER enabled",
+                            StandardKafkaPropertyProvider.AAD_AUTHENTICATION_CALLBACK_HANDLER_CLASS);
+
+                    results.add(new ValidationResult.Builder()
+                            .subject(SASL_MECHANISM.getDisplayName())
+                            .valid(false)
+                            .explanation(explanation)
+                            .build());
+                }
+                String tenantId = validationContext.getProperty(TENANT_ID).evaluateAttributeExpressions().getValue();
+                if (tenantId == null || tenantId.isEmpty()) {
+                    final String explanation = String.format("[%s] required when [%s] mechanism used", TENANT_ID.getDisplayName(), saslMechanism);
+                    results.add(new ValidationResult.Builder()
+                            .subject(TENANT_ID.getDisplayName())
+                            .valid(false)
+                            .explanation(explanation)
+                            .build());
+                }
+                String appId = validationContext.getProperty(APP_ID).evaluateAttributeExpressions().getValue();
+                if (appId == null || appId.isEmpty()) {
+                    final String explanation = String.format("[%s] required when [%s] mechanism used", APP_ID.getDisplayName(), saslMechanism);
+                    results.add(new ValidationResult.Builder()
+                            .subject(APP_ID.getDisplayName())
+                            .valid(false)
+                            .explanation(explanation)
+                            .build());
+                }
+                String appSecret = validationContext.getProperty(APP_SECRET).evaluateAttributeExpressions().getValue();
+                if (appSecret == null || appSecret.isEmpty()) {
+                    final String explanation = String.format("[%s] required when [%s] mechanism used", APP_SECRET.getDisplayName(), saslMechanism);
+                    results.add(new ValidationResult.Builder()
+                            .subject(APP_SECRET.getDisplayName())
+                            .valid(false)
+                            .explanation(explanation)
+                            .build());
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
