### PR TITLE
Change base image

### DIFF
--- a/nifi-docker/pom.xml
+++ b/nifi-docker/pom.xml
@@ -24,7 +24,7 @@ language governing permissions and limitations under the License. -->
     <properties>
         <nifi.version>${project.version}</nifi.version>
         <docker.image.name>nathluu/eclipse-temurin</docker.image.name>
-        <docker.image.tag>11-jre</docker.image.tag>
+        <docker.image.tag>11-jre-minideb</docker.image.tag>
     </properties>
 
     <modules>

--- a/nifi-docker/pom.xml
+++ b/nifi-docker/pom.xml
@@ -23,7 +23,7 @@ language governing permissions and limitations under the License. -->
 
     <properties>
         <nifi.version>${project.version}</nifi.version>
-        <docker.image.name>eclipse-temurin</docker.image.name>
+        <docker.image.name>nathluu/eclipse-temurin</docker.image.name>
         <docker.image.tag>11-jre</docker.image.tag>
     </properties>
 

--- a/nifi-registry/nifi-registry-docker-maven/dockermaven/Dockerfile
+++ b/nifi-registry/nifi-registry-docker-maven/dockermaven/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-FROM nathluu/eclipse-temurin:11-jre AS artifactbase
+FROM nathluu/eclipse-temurin:11-jre-minideb AS artifactbase
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 
@@ -50,7 +50,7 @@ RUN unzip ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}-bin.zi
     && ln -s ${NIFI_TOOLKIT_HOME} ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}
 
 
-FROM nathluu/eclipse-temurin:11-jre
+FROM nathluu/eclipse-temurin:11-jre-minideb
 LABEL maintainer="Apache NiFi Registry <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 

--- a/nifi-registry/nifi-registry-docker-maven/dockermaven/Dockerfile
+++ b/nifi-registry/nifi-registry-docker-maven/dockermaven/Dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-FROM eclipse-temurin:11-jre AS artifactbase
+FROM nathluu/eclipse-temurin:11-jre AS artifactbase
 LABEL maintainer="Apache NiFi <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 
@@ -40,6 +40,9 @@ RUN unzip ${NIFI_REGISTRY_BASE_DIR}/${NIFI_REGISTRY_BINARY_NAME} -d ${NIFI_REGIS
     && rm ${NIFI_REGISTRY_BASE_DIR}/${NIFI_REGISTRY_BINARY_NAME} \
     && ln -s ${NIFI_REGISTRY_BASE_DIR}/nifi-registry-${NIFI_REGISTRY_VERSION} ${NIFI_REGISTRY_HOME}
 
+RUN curl -L -o ${NIFI_REGISTRY_HOME}/lib/postgresql-42.6.0.jar https://repo1.maven.org/maven2/org/postgresql/postgresql/42.6.0/postgresql-42.6.0.jar \
+    && curl -L -o ${NIFI_REGISTRY_HOME}/lib/mssql-jdbc-12.2.0.jre11.jar  https://repo1.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/12.2.0.jre11/mssql-jdbc-12.2.0.jre11.jar
+
 COPY $NIFI_TOOLKIT_BINARY $NIFI_REGISTRY_BASE_DIR
 RUN unzip ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}-bin.zip -d ${NIFI_REGISTRY_BASE_DIR} \
     && rm ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}-bin.zip \
@@ -47,7 +50,7 @@ RUN unzip ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}-bin.zi
     && ln -s ${NIFI_TOOLKIT_HOME} ${NIFI_REGISTRY_BASE_DIR}/nifi-toolkit-${NIFI_REGISTRY_VERSION}
 
 
-FROM eclipse-temurin:11-jre
+FROM nathluu/eclipse-temurin:11-jre
 LABEL maintainer="Apache NiFi Registry <dev@nifi.apache.org>"
 LABEL site="https://nifi.apache.org"
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <okio.version>3.6.0</okio.version>
         <org.apache.commons.cli.version>1.6.0</org.apache.commons.cli.version>
         <org.apache.commons.codec.version>1.16.0</org.apache.commons.codec.version>
-        <org.apache.commons.compress.version>1.25.0</org.apache.commons.compress.version>
+        <org.apache.commons.compress.version>1.26.0</org.apache.commons.compress.version>
         <org.apache.commons.lang3.version>3.14.0</org.apache.commons.lang3.version>
         <org.apache.commons.net.version>3.10.0</org.apache.commons.net.version>
         <org.apache.commons.io.version>2.15.1</org.apache.commons.io.version>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 8
  - [ ] JDK 11
  - [ ] JDK 17

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
