### PR TITLE
Change JDK/JRE base image

### DIFF
--- a/nifi-docker/dockermaven/Dockerfile
+++ b/nifi-docker/dockermaven/Dockerfile
@@ -83,9 +83,9 @@ RUN groupadd -g ${GID} nifi || groupmod -n nifi `getent group ${GID} | cut -d: -
     && useradd --shell /bin/bash -u ${UID} -g ${GID} -m nifi \
     && apt-get update \
     && apt-get install -y jq xmlstarlet procps \
-    && apt-get install -y python3 \
-    && apt-get install -y python3-pip \
-    && apt-get install -y python3-venv \
+#    && apt-get install -y python3 \
+#    && apt-get install -y python3-pip \
+#    && apt-get install -y python3-venv \
     && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean autoclean \

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,9 @@
         <maven.surefire.arguments />
         <!-- Disable maven-site-plugin from parent POM -->
         <maven.site.skip>true</maven.site.skip>
-        <docker.jdk.image.name>nathluu/eclipse-temurin</docker.jdk.image.name>
-        <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
-        <docker.image.tag>21-jdk-minideb</docker.image.tag>
+        <docker.jdk.image.name>nathluu/eclipse-temurin-jdk</docker.jdk.image.name>
+        <docker.jre.image.name>nathluu/eclipse-temurin-jre</docker.jre.image.name>
+        <docker.image.tag>21</docker.image.tag>
         <node.version>v22.1.0</node.version>
         <frontend.mvn.plugin.version>1.15.0</frontend.mvn.plugin.version>
         <nifi.nar.maven.plugin.version>2.0.0</nifi.nar.maven.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,9 @@
         <maven.surefire.arguments />
         <!-- Disable maven-site-plugin from parent POM -->
         <maven.site.skip>true</maven.site.skip>
-        <docker.jdk.image.name>bellsoft/liberica-openjdk-debian</docker.jdk.image.name>
+        <docker.jdk.image.name>nathluu/eclipse-temurin</docker.jdk.image.name>
         <docker.jre.image.name>bellsoft/liberica-openjre-debian</docker.jre.image.name>
-        <docker.image.tag>21</docker.image.tag>
+        <docker.image.tag>21-jdk-minideb</docker.image.tag>
         <node.version>v22.1.0</node.version>
         <frontend.mvn.plugin.version>1.15.0</frontend.mvn.plugin.version>
         <nifi.nar.maven.plugin.version>2.0.0</nifi.nar.maven.plugin.version>


### PR DESCRIPTION
<!-- Licensed to the Apache Software Foundation (ASF) under one or more -->
<!-- contributor license agreements.  See the NOTICE file distributed with -->
<!-- this work for additional information regarding copyright ownership. -->
<!-- The ASF licenses this file to You under the Apache License, Version 2.0 -->
<!-- (the "License"); you may not use this file except in compliance with -->
<!-- the License.  You may obtain a copy of the License at -->
<!--     http://www.apache.org/licenses/LICENSE-2.0 -->
<!-- Unless required by applicable law or agreed to in writing, software -->
<!-- distributed under the License is distributed on an "AS IS" BASIS, -->
<!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
<!-- See the License for the specific language governing permissions and -->
<!-- limitations under the License. -->

# Summary

[NIFI-00000](https://issues.apache.org/jira/browse/NIFI-00000)

# Tracking

Please complete the following tracking steps prior to pull request creation.

### Issue Tracking

- [ ] [Apache NiFi Jira](https://issues.apache.org/jira/browse/NIFI) issue created

### Pull Request Tracking

- [ ] Pull Request title starts with Apache NiFi Jira issue number, such as `NIFI-00000`
- [ ] Pull Request commit message starts with Apache NiFi Jira issue number, as such `NIFI-00000`

### Pull Request Formatting

- [ ] Pull Request based on current revision of the `main` branch
- [ ] Pull Request refers to a feature branch with one commit containing changes

# Verification

Please indicate the verification steps performed prior to pull request creation.

### Build

- [ ] Build completed using `mvn clean install -P contrib-check`
  - [ ] JDK 21

### Licensing

- [ ] New dependencies are compatible with the [Apache License 2.0](https://apache.org/licenses/LICENSE-2.0) according to the [License Policy](https://www.apache.org/legal/resolved.html)
- [ ] New dependencies are documented in applicable `LICENSE` and `NOTICE` files

### Documentation

- [ ] Documentation formatting appears as expected in rendered files
